### PR TITLE
Add python 2 versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     - run:
         name: Docker Build
         command: |
-          export VERSIONS="latest 3.6 3.6.4 3.5 3.5.5"
+          export VERSIONS="latest 2.7 2.7.14 3.6 3.6.4 3.5 3.5.5"
           for VERSION in ${VERSIONS}; do
             export TAG="ixai/pipenv:${VERSION}"
             docker build . --build-arg PYTHON="${VERSION}" -t "${TAG}"


### PR DESCRIPTION
Some packages depend on python 2, e.g. bender.